### PR TITLE
Remove workaround for bufbuild/buf#4248

### DIFF
--- a/accrescent/appstore/publish/v1alpha1/update_app_draft_request.proto
+++ b/accrescent/appstore/publish/v1alpha1/update_app_draft_request.proto
@@ -28,9 +28,6 @@ message UpdateAppDraftRequest {
   // The list of fields to update.
   //
   // Required to enforce forward-compatible use by clients.
-  //
-  // Workaround for https://github.com/bufbuild/buf/issues/4248
-  // buf:lint:ignore PROTOVALIDATE
   google.protobuf.FieldMask update_mask = 3 [
     (buf.validate.field).required = true,
     (buf.validate.field).field_mask.in = "default_listing_language"


### PR DESCRIPTION
The fix for this issue is now released in Buf 1.63.0, so we no longer need this workaround.

Closes #4